### PR TITLE
Added suport for excluding parameters in child errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,6 @@ SimpleError.define = function (name, opts) {
 
     if (Constructor.super_ && Constructor.super_.prototype.friendly){
       iterator = Constructor.super_.prototype.friendly.apply(this);
-      result = { success: false };
     }
 
     Object.keys(iterator)
@@ -96,6 +95,7 @@ SimpleError.define = function (name, opts) {
       result.stack = this.stack;
     }
 
+    result.success = false;
     return result;
   };
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,14 @@ SimpleError.define = function (name, opts) {
   Constructor.prototype.friendly = function friendly() {
     var result = { success: false };
 
-    Object.keys(this)
+    var iterator = this;
+
+    if (Constructor.super_ && Constructor.super_.prototype.friendly){
+      iterator = Constructor.super_.prototype.friendly.apply(this);
+      result = { success: false };
+    }
+
+    Object.keys(iterator)
       .filter(function (prop) {
         return excludedProps.indexOf(prop) === -1;
       })
@@ -114,8 +121,10 @@ SimpleError.define = function (name, opts) {
     opts = args.opts || {};
 
     var Child = SimpleError.define(name, opts);
+    var friendly = Child.prototype.friendly;
     util.inherits(Child, Constructor);
     copyMethodsToPrototype(Child, opts.methods);
+    Child.prototype.friendly = friendly;
 
     return Child;
   };
@@ -124,4 +133,3 @@ SimpleError.define = function (name, opts) {
 
   return Constructor;
 };
-

--- a/tests/inheritance.js
+++ b/tests/inheritance.js
@@ -12,6 +12,9 @@ var ApiError = SimpleError.define('ApiError', {
   }
 });
 
+
+
+
 var NotFoundError = ApiError.define('NotFoundError', {
   code: 4004,
   statusCode: 404,
@@ -39,6 +42,17 @@ var ErrorWithCtor = ApiError.define('ErrorWithCtor', {
       }
     }
   }
+});
+
+var ApiErrorWithExclude = SimpleError.define('ApiErrorWithExclude', {
+  code: 5005,
+  statusCode: 500,
+  message: 'api error',
+  exclude: ['statusCode']
+});
+
+var ErrorWithExcludeProps = ApiErrorWithExclude.define('ErrorWithExcludeProps', {
+  exclude: ['message']
 });
 
 test('api error', function (t) {
@@ -125,4 +139,14 @@ test('should exclude props defined in parent', function (t) {
 	});
 
 	t.end();
+});
+
+test('excluded properties with inheritens', function(t){
+  var err = new ErrorWithExcludeProps();
+  var friendly = err.friendly();
+  t.ok(friendly.statusCode === undefined);
+  t.ok(friendly.message === undefined);
+  t.ok(friendly.code === 0);
+  t.end();
+
 });

--- a/tests/inheritance.js
+++ b/tests/inheritance.js
@@ -52,7 +52,7 @@ var ApiErrorWithExclude = SimpleError.define('ApiErrorWithExclude', {
 });
 
 var ErrorWithExcludeProps = ApiErrorWithExclude.define('ErrorWithExcludeProps', {
-  exclude: ['message']
+  exclude: ['message', 'customInt']
 });
 
 test('api error', function (t) {
@@ -138,15 +138,41 @@ test('should exclude props defined in parent', function (t) {
 		t.notOk(friendly[prop]);
 	});
 
+  t.ok(friendly.success === false, 'Success should be false');
+
 	t.end();
 });
 
 test('excluded properties with inheritens', function(t){
   var err = new ErrorWithExcludeProps();
+  err.customMessage = 'message2';
+  err.customInt = 2;
   var friendly = err.friendly();
   t.ok(friendly.statusCode === undefined);
   t.ok(friendly.message === undefined);
   t.ok(friendly.code === 0);
+  t.ok(friendly.customMessage === 'message2');
+  t.ok(friendly.customInt === undefined);
+  t.ok(friendly.success === false, 'Success should be false');
+  t.end();
+
+});
+
+test('excluded properties with inheritens in two layers', function(t){
+  var NewError = ErrorWithExcludeProps.define('NewError', {
+    exclude: ['customString']
+  });
+
+  var err = new NewError();
+  err.customString = 'Shold be excluded';
+  err.customString2 = 'Should be included';
+  var friendly = err.friendly();
+  t.ok(friendly.statusCode === undefined);
+  t.ok(friendly.message === undefined);
+  t.ok(friendly.code === 0);
+  t.ok(friendly.customString === undefined);
+  t.ok(friendly.success === false, 'Success should be false');
+  t.ok(friendly.customString2 === 'Should be included');
   t.end();
 
 });


### PR DESCRIPTION
Excluded properties on inherited errors did not work.

When rewriting the prototype chain in Constructor.define the
Child.prototype.friendly was overwritten and the original scope 
was lost. This is fixed by restoring the original friendly method on the 
prototype and recurse in the inherited prototype chain in the friendly 
method.
