### PR TITLE
Added suport for excluding parameters in child errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
+
+/*jshint node:true */
+
 var assert = require('assert');
 var util = require('util');
-var NON_JSON_PROPS = ['isError'];
+var NON_JSON_PROPS = ['isError', 'exclude', 'showStack'];
 
 var copyMethodsToPrototype = function (ctor, methods) {
   if (methods) {
@@ -11,11 +14,50 @@ var copyMethodsToPrototype = function (ctor, methods) {
   }
 };
 
+var setDefaults = function(opts){
+  var defaults = {
+    code: 0,
+    statusCode: 500,
+    showStack: false
+  };
+
+  Object.keys(defaults).forEach(function(prop){
+    if (prop in opts){}
+    else
+      opts[prop] = defaults[prop];
+  });
+
+  return opts;
+};
+
+var ErrorConstructor = function(Constructor, name, opts, args) {
+  this.name = this.type = name;
+
+  Object.keys(opts).forEach(function(prop){
+    this[prop] = opts[prop];
+  }.bind(this));
+
+  copyMethodsToPrototype(Constructor, opts.methods);
+
+  if (opts.ctor) {
+    this.message = opts.message || 'Unknown';
+    opts.ctor.apply(this, args);
+  } else {
+    if (opts.message) {
+      args.unshift(opts.message);
+    }
+    this.message = args.length ? util.format.apply(null, args) : 'Unknown';
+  }
+  if (this.ctor) this.ctor.apply(this, args);
+
+  Error.captureStackTrace(this, this.constructor);
+};
+
 var extractArgs = function(name, opts) {
   assert.ok(name, 'Error name is required');
   assert.ok(typeof(name) === 'string', 'Error name must be a string');
 
-  return { name: name.trim(), opts: opts };
+  return { name: name.trim(), opts: opts || {} };
 };
 
 var SimpleError = module.exports = {};
@@ -27,73 +69,41 @@ SimpleError.isError = function (error) {
 SimpleError.define = function (name, opts) {
   var args = extractArgs(name, opts);
   name = args.name;
-  opts = args.opts;
+  opts = setDefaults(args.opts);
 
-  var code = 0,
-    statusCode = 500,
-    showStack = false,
-    messageFormatString,
-    excludedProps = [],
-    ctor;
-
-  if (opts) {
-    code = opts.code || code;
-    statusCode = opts.statusCode || statusCode;
-    messageFormatString = opts.message;
-    showStack = opts.showStack || showStack;
-    excludedProps = NON_JSON_PROPS.concat(opts.exclude || []);
-    if (opts.ctor && typeof opts.ctor === 'function') {
-      ctor = opts.ctor;
-    }
+  function BaseError() {
+    ErrorConstructor.call(this, BaseError, name, opts, [].slice.call(arguments));
+    this.exclude = NON_JSON_PROPS.concat(opts.exclude || []);
   }
 
-  function Constructor() {
-    var args = [].slice.call(arguments);
+  BaseError.prototype = Object.create(Error.prototype);
+  BaseError.prototype.constructor = BaseError;
 
-    Error.captureStackTrace(this, this.constructor);
-
-    this.name = this.type = name;
-    this.code = code;
-    this.statusCode = statusCode;
-    this.isError = true;
-
-    if (ctor) {
-      this.message = messageFormatString || 'Unknown';
-      ctor.apply(this, args);
-    } else {
-      if (messageFormatString) {
-        args.unshift(messageFormatString);
-      }
-      this.message = args.length ? util.format.apply(null, args) : 'Unknown';
-    }
-  }
-
-  Constructor.prototype = Object.create(Error.prototype);
-
-  Constructor.prototype.toJSON = function toJSON() {
+  BaseError.prototype.toJSON = function toJSON() {
     return JSON.stringify(this.friendly());
   };
 
-  Constructor.prototype.friendly = function friendly() {
+  BaseError.prototype.friendly = function friendly() {
     var result = { success: false };
+    var self = this;
 
-    Object.keys(this)
+    Object.keys(self)
       .filter(function (prop) {
-        return excludedProps.indexOf(prop) === -1;
+        return self.exclude.indexOf(prop) === -1;
       })
       .forEach(function (prop) {
-        result[prop] = this[prop];
-      }.bind(this));
+        result[prop] = self[prop];
+      });
 
-    if (showStack) {
-      result.stack = this.stack;
+    if (self.showStack) {
+      result.stack = self.stack;
     }
 
     return result;
   };
 
-  Constructor.wrap = function (error) {
-    var err = new Constructor();
+  BaseError.wrap = function (error) {
+    var err = new BaseError();
 
     Object.keys(error).forEach(function (prop) {
       if (prop !== 'name' && prop !== 'type') {
@@ -108,20 +118,28 @@ SimpleError.define = function (name, opts) {
     return err;
   };
 
-  Constructor.define = function (name, opts) {
+  BaseError.define = function (name, opts) {
     var args = extractArgs(name, opts);
     name = args.name;
-    opts = args.opts || {};
+    opts = args.opts;
+    var parent = this;
 
-    var Child = SimpleError.define(name, opts);
-    util.inherits(Child, Constructor);
-    copyMethodsToPrototype(Child, opts.methods);
+    function ChildError(){
+      var args = [].slice.call(arguments);
 
-    return Child;
+      parent.apply(this, arguments);
+      var parentExclude = this.exclude;
+      ErrorConstructor.call(this, BaseError, name, opts, args);
+
+      this.exclude = this.exclude.concat(parentExclude || []);
+    }
+
+    ChildError.prototype = Object.create(parent.prototype);
+    ChildError.prototype.constructor = ChildError;
+    ChildError.define = BaseError.define;
+
+    return ChildError;
   };
 
-  copyMethodsToPrototype(Constructor, (opts || {}).methods);
-
-  return Constructor;
+  return BaseError;
 };
-


### PR DESCRIPTION
Excluded properties on inherited errors did not work.

Refactored internal names to make it more clear what is going
on. Made sure the prototype chain is correct and that the
excluded properties are from parent errors are propagated to
errors that are inherits from a parent error.
