### PR TITLE
Don't omit this.constructor when using captureStackTrace because it removes call site

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ var define = function define(name, opts) {
     var cargs = [].slice.call(arguments);
 
     if (typeof Error.captureStackTrace === 'function') {
-      Error.captureStackTrace(this, this.constructor);
+      Error.captureStackTrace(this);
     }
 
     this.name = this.type = name;


### PR DESCRIPTION
Just did a bunch of debugging (I've never used `captureStackTrace` before) and found that the second argument is which frame you want to begin omitting from.  This removed the entire stack trace and I couldn't see where the object was thrown.  This change fixes that.
